### PR TITLE
Use latest version of sbt

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.3
+sbt.version=1.8.2


### PR DESCRIPTION
何やら警告が出たりもしているので、sbt のバージョンを上げてみます。

```
WARNING: A terminally deprecated method in java.lang.System has been called
WARNING: System::setSecurityManager has been called by sbt.TrapExit$ (file:/home/thinca/.sbt/boot/scala-2.12.14/org.scala-sbt/sbt/1.5.3/run_2.12-1.5.3.jar)
WARNING: Please consider reporting this to the maintainers of sbt.TrapExit$
WARNING: System::setSecurityManager will be removed in a future release
```

ローカルのリポジトリ以下に古いビルド用のファイルがあるとビルドに失敗する場合があるようなので、その場合はそれらのファイルを消してみると直るかもしれません。

```
# リポジトリ管理下にないファイルを全て消す (未コミットファイルも全て消えるので注意)
$ git clean -dfx
```