### PR TITLE
Remove sbt-maven-resolver

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,0 @@
-// For adding spigot-api dependencies
-addSbtPlugin("org.scala-sbt" % "sbt-maven-resolver" % "0.1.0")


### PR DESCRIPTION
This leads to dependency conflicts.

```
* org.scala-lang.modules:scala-xml_2.12:2.1.0 (early-semver) is selected over {1.2.0}
    +- org.scala-lang:scala-compiler:2.12.17              (depends on 2.1.0)
    +- org.scala-sbt:librarymanagement-core_2.12:1.3.2    (depends on 1.2.0)
```

特に metals を使っていて、`New sbt workspace detected, would you like to import the build?` → `Import build` を選択するとこの状態になる。

ちゃんとわかっていないが、これがなくても問題なく依存の解決はできるようなので削除する。