### PR TITLE
fix: call "updateCapacityView" if only the mode is active

### DIFF
--- a/src/main/scala/org/vim_jp/modal/mode/Mode.scala
+++ b/src/main/scala/org/vim_jp/modal/mode/Mode.scala
@@ -107,8 +107,9 @@ abstract class Mode(plugin: MODalPlugin) extends Listener:
   @EventHandler
   def onPlayerJoin(event: PlayerJoinEvent): Unit =
     val player = event.getPlayer
-    if isActive(player) then notifyActive(player)
-    updateCapacityView(player)
+    if isActive(player) then
+      notifyActive(player)
+      updateCapacityView(player)
 
   def consume(player: Player): Unit =
     val container = player.getPersistentDataContainer()


### PR DESCRIPTION
- PlayerJoinのイベントに対して、updateCapacityViewが、全てのModeで呼ばれていた。
- 結果、Capacityの現在値が128(FarmerModeの最大値)で、TeleporterのModeのupdateCapacityViewが呼ばれたりして、エラーになってた。
- 当該ModeでのupdateCapacityViewはそのMode自体が有効なプレイヤーに対してのみ呼ばれるべき。。


多分インデントミスったままFormat係っちゃったヤツ。
