### PR TITLE
Do not notify mode on PlayerJoin

### DIFF
--- a/src/main/scala/org/vim_jp/modal/mode/Mode.scala
+++ b/src/main/scala/org/vim_jp/modal/mode/Mode.scala
@@ -107,9 +107,7 @@ abstract class Mode(plugin: MODalPlugin) extends Listener:
   @EventHandler
   def onPlayerJoin(event: PlayerJoinEvent): Unit =
     val player = event.getPlayer
-    if isActive(player) then
-      notifyActive(player)
-      updateCapacityView(player)
+    if isActive(player) then updateCapacityView(player)
 
   def consume(player: Player): Unit =
     val container = player.getPersistentDataContainer()


### PR DESCRIPTION
ログインする度にモードが通知されるのは邪魔ではないだろうか、ということで通知を消すのはどうでしょうか。